### PR TITLE
feat: implementar ver perfiles y documentacion

### DIFF
--- a/src/application/use-cases/get-profiles.use-case.ts
+++ b/src/application/use-cases/get-profiles.use-case.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { PerfilService } from 'src/core/services/perfil/perfil.service';
+import { Result } from 'src/shared/domain/result/result';
+
+@Injectable()
+export class GetProfilesUseCase {
+    constructor(
+        private readonly perfilService: PerfilService,
+    ) {}
+    async execute(userId: number) {
+       try {
+            const perfiles = await this.perfilService.verPerfil(userId);
+            return Result.ok(perfiles); 
+        } catch (error) {
+            return Result.fail(new Error(error.message));
+        }
+}
+}

--- a/src/core/services/perfil/perfil.service.ts
+++ b/src/core/services/perfil/perfil.service.ts
@@ -1,4 +1,4 @@
-import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { CreateProfileDto } from 'src/application/dto/create-profile.dto';
 import { PerfilRepository } from 'src/core/repositories/perfil.repository';
 import { ValidatorService } from 'src/shared/application/validation/validator.service';
@@ -45,5 +45,12 @@ export class PerfilService {
         );
         
         return this.repository.create(perfil)   ;
+}
+async verPerfil(userId: number): Promise<Perfil[]> {
+    const perfiles = await this.repository.findAllByUserId(userId);
+    if (perfiles.length === 0) {
+        throw new NotFoundException('No se encontraron perfiles para este usuario');
+    }
+    return perfiles;
 }
 }

--- a/src/infrastructure/http/perfil/perfil.controller.ts
+++ b/src/infrastructure/http/perfil/perfil.controller.ts
@@ -1,16 +1,25 @@
-import { Body, Controller, HttpException, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CreateProfileDto } from 'src/application/dto/create-profile.dto';
 import { CreateProfileUseCase } from 'src/application/use-cases/create-profile.use-case';
+import { GetProfilesUseCase } from 'src/application/use-cases/get-profiles.use-case';
 import { JwtPayload } from 'src/core/services/auth/jwtPayload';
 import { CurrentUser } from 'src/shared/decorator/current-user.decorator';
 import { jwtAuthGuard } from 'src/shared/guard/jwtAuth.guard';
 
-@Controller('perfil')
+@ApiTags('Perfil')       
+@ApiBearerAuth()
+@Controller('profile')
 @UseGuards(jwtAuthGuard)
 export class PerfilController {
-     constructor(private readonly createProfileUseCase: CreateProfileUseCase ) {}
+    constructor(private readonly createProfileUseCase: CreateProfileUseCase
+        ,private readonly verPerfilesUseCase: GetProfilesUseCase
+     ) {}
 
-    @Post('crear')
+    @Post('create')
+    @ApiOperation({ summary: 'Crear perfil', description: 'Crea un nuevo perfil vinculado al usuario autenticado.' })
+    @ApiResponse({ status: 201, description: 'Perfil creado con éxito.' })
+    @ApiResponse({ status: 400, description: 'Error en la validación o regla de negocio.' })
     async create(@CurrentUser() userId: JwtPayload, @Body() dto: CreateProfileDto) {
         
         const user = Number(userId.sub);
@@ -28,6 +37,34 @@ export class PerfilController {
             imageurl: perfil.imageurl
         },
         message: 'Perfil creado con éxito'
-    };       
+    }  
 }
+@Get()
+    @ApiOperation({ 
+        summary: 'Listar perfiles', 
+        description: 'Obtiene todos los perfiles asociados al usuario autenticado.' 
+    })
+    @ApiResponse({ 
+        status: 200, 
+        description: 'Lista obtenida con éxito.',
+        schema: {
+            example: {
+                data: [
+                    { id: 1, nombre: 'Perfil 1', idusuario: 33, idrol: 4, estado: 1, imageurl: '...' }
+                ]
+            }
+        }
+    })
+    @ApiResponse({ status: 404, description: 'No se encontraron perfiles para este usuario.' })
+    async verPerfiles(@CurrentUser() userId: JwtPayload) {
+        const user = Number(userId.sub);
+        const result = await this.verPerfilesUseCase.execute(user);
+        if (result.isFailure) {
+        throw new HttpException(result.error.message, HttpStatus.NOT_FOUND);
+        }
+        return {
+        data: result.getValue(),
+        message: 'Perfles obtenidos con éxito'
+    };
+    }
 }

--- a/src/infrastructure/http/perfil/perfil.module.ts
+++ b/src/infrastructure/http/perfil/perfil.module.ts
@@ -6,6 +6,7 @@ import { PERFIL_REPOSITORY } from 'src/core/constants/constants';
 import { PerfilPrismaRepository } from 'src/infrastructure/persistence/perfil/perfil.prisma.repository';
 import { PrismaService } from 'src/core/services/prisma/prisma.service';
 import { ValidatorService } from 'src/shared/application/validation/validator.service';
+import { GetProfilesUseCase } from 'src/application/use-cases/get-profiles.use-case';
 
 @Module({
   controllers: [PerfilController],
@@ -17,7 +18,8 @@ import { ValidatorService } from 'src/shared/application/validation/validator.se
     PerfilService,
     CreateProfileUseCase,
     PrismaService, 
-    ValidatorService,   
+    ValidatorService, 
+    GetProfilesUseCase  
 ],
   exports: [PerfilService],
 })

--- a/src/infrastructure/persistence/perfil/perfil.prisma.repository.ts
+++ b/src/infrastructure/persistence/perfil/perfil.prisma.repository.ts
@@ -21,7 +21,12 @@ export class PerfilPrismaRepository implements PerfilRepository {
     }
 
      async findAllByUserId(userId: number): Promise<Perfil[]> {
-        const data= await this.prisma.perfil.findMany({where: {idusuario:userId}})
+        const data= await this.prisma.perfil.findMany({where: { idusuario: userId },
+        select: {
+        nombre: true,
+        estado: true,
+        imageurl: true,
+        },})
         return data.map((p) => Perfil.fromPrisma(p));
     }
   


### PR DESCRIPTION
Implementa servicio de ver perfil.
Issue relacionada: #19 
Cambios principales:
- Se desarrolla el endpoint GET /profile para listar perfiles vinculados al usuario autenticado usando JwtPayload.
- Se implementa validación en el servicio para retornar 404 Not Found si el usuario no tiene perfiles.
- Se optimizó la consulta en el repositorio para excluir datos sensibles de la respuesta.
- -Se realiza la documentación en Swagger de los endpoints GET /profile y POST/create