### PR TITLE
feat: implementar actualizar perfil

### DIFF
--- a/src/application/dto/update-profile.dto.ts
+++ b/src/application/dto/update-profile.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class UpdateProfileDto {
+    @ApiProperty({ example: 'Jose', description: 'Nombre del perfil', required: false })
+    @IsString({message: 'El nombre del perfil debe ser un texto valido'})
+    @IsOptional()
+    nombre?: string;
+    
+    @ApiProperty({ example: 'https://nueva-imagen.com/foto.png', required: false })
+    @IsOptional()
+    @IsUrl({}, { message: 'La URL de la imagen no es válida' })
+    imageurl?: string;
+}

--- a/src/application/use-cases/update-profile.use-case.ts
+++ b/src/application/use-cases/update-profile.use-case.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { Perfil } from 'src/core/entities/perfil/perfil.entity';
+import { Result } from 'src/shared/domain/result/result';
+import { UpdateProfileDto } from '../dto/update-profile.dto';
+import { PerfilService } from 'src/core/services/perfil/perfil.service';
+
+@Injectable()
+export class UpdateProfileUseCase {
+    constructor(private readonly perfilService: PerfilService) {}
+    async execute(perfilId: number, userId: number, data: UpdateProfileDto): Promise<Result<Perfil>> {
+        try {
+            const perfilActualizado = await this.perfilService.updatePerfil(perfilId, userId, data);
+            return Result.ok(perfilActualizado);
+        } catch (error) {
+            return Result.fail(error);
+        }
+    }
+}

--- a/src/core/repositories/perfil.repository.ts
+++ b/src/core/repositories/perfil.repository.ts
@@ -3,4 +3,6 @@ import { Perfil } from '../entities/perfil/perfil.entity';
 export interface PerfilRepository {
   create(perfil: Perfil): Promise<Perfil>;
   findAllByUserId(userId: number): Promise<Perfil[]>;
+  findProfileById(perfilId: number, userId: number): Promise<Perfil>;
+  update(perfilId: number, userId: number, updatedData: Partial<Perfil>): Promise<Perfil>;
 }

--- a/src/core/services/perfil/perfil.service.ts
+++ b/src/core/services/perfil/perfil.service.ts
@@ -6,6 +6,7 @@ import { BussinesRuleException } from 'src/shared/domain/exceptions/business-rul
 import * as bcrypt from 'bcrypt';
 import { Perfil } from 'src/core/entities/perfil/perfil.entity';
 import { PERFIL_REPOSITORY } from 'src/core/constants/constants';
+import { UpdateProfileDto } from 'src/application/dto/update-profile.dto';
 
 @Injectable()
 export class PerfilService {
@@ -52,5 +53,12 @@ async verPerfil(userId: number): Promise<Perfil[]> {
         throw new NotFoundException('No se encontraron perfiles para este usuario');
     }
     return perfiles;
+}
+async updatePerfil(perfilId: number, userId: number, data: UpdateProfileDto) {
+    const existe= await this.repository.findProfileById(perfilId, userId);
+    if(!existe){
+        throw new NotFoundException('Perfil no existe');
+    }
+    return this.repository.update(perfilId, userId, data);
 }
 }

--- a/src/infrastructure/http/perfil/perfil.controller.ts
+++ b/src/infrastructure/http/perfil/perfil.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpException, HttpStatus, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CreateProfileDto } from 'src/application/dto/create-profile.dto';
+import { UpdateProfileDto } from 'src/application/dto/update-profile.dto';
 import { CreateProfileUseCase } from 'src/application/use-cases/create-profile.use-case';
 import { GetProfilesUseCase } from 'src/application/use-cases/get-profiles.use-case';
+import { UpdateProfileUseCase } from 'src/application/use-cases/update-profile.use-case';
 import { JwtPayload } from 'src/core/services/auth/jwtPayload';
 import { CurrentUser } from 'src/shared/decorator/current-user.decorator';
 import { jwtAuthGuard } from 'src/shared/guard/jwtAuth.guard';
@@ -14,6 +16,8 @@ import { jwtAuthGuard } from 'src/shared/guard/jwtAuth.guard';
 export class PerfilController {
     constructor(private readonly createProfileUseCase: CreateProfileUseCase
         ,private readonly verPerfilesUseCase: GetProfilesUseCase
+        ,private readonly updateProfileUseCase: UpdateProfileUseCase
+
      ) {}
 
     @Post('create')
@@ -66,5 +70,28 @@ export class PerfilController {
         data: result.getValue(),
         message: 'Perfles obtenidos con éxito'
     };
+    }
+    @Patch(':id')
+    @ApiOperation({ summary: 'Update profile', description: 'Updates specific fields of a profile.' })
+    @ApiResponse({ status: 200, description: 'Profile updated successfully.' })
+    @ApiResponse({ status: 404, description: 'Profile not found.' })
+    async update(
+        @Param('id') id: string,
+        @CurrentUser() userToken: JwtPayload,
+        @Body() dto: UpdateProfileDto
+    ) {
+        const userId = Number(userToken.sub);
+        const profileId = Number(id);
+
+        const result= await this.updateProfileUseCase .execute(profileId, userId, dto);
+
+        if (result.isFailure) {
+            throw new HttpException(result.error.message, HttpStatus.NOT_FOUND);
+        }
+
+        return {
+            data: result.getValue(),
+            message: 'Perfil actualizado con éxito'
+        };
     }
 }

--- a/src/infrastructure/http/perfil/perfil.module.ts
+++ b/src/infrastructure/http/perfil/perfil.module.ts
@@ -7,6 +7,7 @@ import { PerfilPrismaRepository } from 'src/infrastructure/persistence/perfil/pe
 import { PrismaService } from 'src/core/services/prisma/prisma.service';
 import { ValidatorService } from 'src/shared/application/validation/validator.service';
 import { GetProfilesUseCase } from 'src/application/use-cases/get-profiles.use-case';
+import { UpdateProfileUseCase } from 'src/application/use-cases/update-profile.use-case';
 
 @Module({
   controllers: [PerfilController],
@@ -19,7 +20,8 @@ import { GetProfilesUseCase } from 'src/application/use-cases/get-profiles.use-c
     CreateProfileUseCase,
     PrismaService, 
     ValidatorService, 
-    GetProfilesUseCase  
+    GetProfilesUseCase ,
+    UpdateProfileUseCase
 ],
   exports: [PerfilService],
 })

--- a/src/infrastructure/persistence/perfil/perfil.prisma.repository.ts
+++ b/src/infrastructure/persistence/perfil/perfil.prisma.repository.ts
@@ -23,11 +23,36 @@ export class PerfilPrismaRepository implements PerfilRepository {
      async findAllByUserId(userId: number): Promise<Perfil[]> {
         const data= await this.prisma.perfil.findMany({where: { idusuario: userId },
         select: {
+        id: true,
         nombre: true,
         estado: true,
         imageurl: true,
         },})
         return data.map((p) => Perfil.fromPrisma(p));
     }
+
+    async update(perfilId: number, userId: number, updatedData: Partial<Perfil>): Promise<Perfil> {
+        const data = await this.prisma.perfil.update({
+            where: { id: perfilId, idusuario: userId },
+            data: updatedData,
+            select: {
+                id: true,
+                nombre: true,
+                estado: true,
+                imageurl: true,
+            }
+        });
+        return Perfil.fromPrisma(data);
+    }
+    
+    async findProfileById(perfilId: number, userId: number): Promise<Perfil | null> {
+    const data = await this.prisma.perfil.findFirst({
+        where: { 
+            id: perfilId, 
+            idusuario: userId 
+        },
+    });
+    return data ? Perfil.fromPrisma(data) : null;
+}
   
 }


### PR DESCRIPTION
Implementa servicio de actualizar perfil.
Issue relacionada: #20 
Cambios principales:
- Se implementa el endpoint PATCH /profile/:id para la edición de perfiles.
- Se añade la lógica en el servicio para la actualización de nombre e imagen del perfil.
- Se crea el UpdateProfileDto con validaciones para campos opcionales.
- Se incorpora validación previa mediante búsqueda por ID para retornar error 404 en caso de que el perfil no exista.